### PR TITLE
Feature/sq lint

### DIFF
--- a/src/SqlDsl.Core/SqlCompiler.cs
+++ b/src/SqlDsl.Core/SqlCompiler.cs
@@ -35,7 +35,7 @@ namespace SqlDsl.Core
 				SqlBoolAnd(var left, var right) => $"({EmitExpr(left)} AND {EmitExpr(right)})",
 				SqlBoolOr(var left, var right) => $"({EmitExpr(left)} OR {EmitExpr(right)})",
 
-        SqlStringValue(var value) => $"'{value}'",
+				SqlStringValue(var value) => $"'{value}'",
 				SqlStringToUpper(var value) => $"{EmitExpr(value).ToUpper()}",
 				SqlStringToLower(var value) => $"{EmitExpr(value).ToLower()}" ,
           

--- a/src/SqlDsl.Core/SqlCompiler.cs
+++ b/src/SqlDsl.Core/SqlCompiler.cs
@@ -4,22 +4,22 @@ namespace SqlDsl.Core
 {
 	public static class SqlCompiler
 	{
-
 		private static SqlExpr OptimizeExpr(SqlExpr expr) =>
 			expr switch
 			{
 				SqlIntAdd(SqlIntValue(var left), SqlIntValue(var right)) => new SqlIntValue(left + right),
 				SqlIntAdd(var left, SqlIntValue(0)) => OptimizeExpr(left),
 				SqlIntAdd(SqlIntValue(0), var right) => OptimizeExpr(right),
-				SqlIntAdd(var left, var right) => new SqlIntAdd(OptimizeExpr(left) as SqlExprInt, OptimizeExpr(right) as SqlExprInt),
+				SqlIntAdd(var left, var right) => new SqlIntAdd(OptimizeExpr(left) as SqlExprInt,
+					OptimizeExpr(right) as SqlExprInt),
 				_ => expr
 			};
 
 		public static SqlExpr MultiOptimizer(SqlExpr expr)
 		{
 			var optExpr = OptimizeExpr(expr);
-			return expr == optExpr 
-				? optExpr 
+			return expr == optExpr
+				? optExpr
 				: MultiOptimizer(optExpr);
 		}
 
@@ -35,10 +35,10 @@ namespace SqlDsl.Core
 				SqlBoolAnd(var left, var right) => $"({EmitExpr(left)} AND {EmitExpr(right)})",
 				SqlBoolOr(var left, var right) => $"({EmitExpr(left)} OR {EmitExpr(right)})",
 
-        SqlStringValue(var value) => $"'{value}'",
+				SqlStringValue(var value) => $"'{value}'",
 				SqlStringToUpper(var value) => $"{EmitExpr(value).ToUpper()}",
-				SqlStringToLower(var value) => $"{EmitExpr(value).ToLower()}" ,
-          
+				SqlStringToLower(var value) => $"{EmitExpr(value).ToLower()}",
+
 				// Expressions - Numeric
 				SqlIntAdd(var left, var right) => $"({CompileExpr(left)} + {CompileExpr(right)})",
 				SqlIntSub(var left, var right) => $"({CompileExpr(left)} - {CompileExpr(right)})",
@@ -46,9 +46,10 @@ namespace SqlDsl.Core
 				SqlIntPlus(var value) => $"({CompileExpr(value)})",
 				SqlIntMinus(var value) => $"(-({CompileExpr(value)}))",
 				SqlIntAbs(var value) => $"(ABS({CompileExpr(value)}))",
-          
+
 				_ => throw new Exception($"Not supported {expr}")
 			};
+
 		public static string CompileExpr(this SqlExpr expr) => EmitExpr(MultiOptimizer(expr));
 	}
 }

--- a/src/SqlDsl.Core/SqlCompiler.cs
+++ b/src/SqlDsl.Core/SqlCompiler.cs
@@ -23,7 +23,7 @@ namespace SqlDsl.Core
 				: MultiOptimizer(optExpr);
 		}
 
-		private static string EmitExpr(SqlExpr expr) =>
+		public static string EmitExpr(SqlExpr expr) =>
 			expr switch
 			{
 				// Values

--- a/src/SqlDsl.Core/SqlCompiler.cs
+++ b/src/SqlDsl.Core/SqlCompiler.cs
@@ -18,9 +18,9 @@ namespace SqlDsl.Core
 		public static SqlExpr MultiOptimizer(SqlExpr expr)
 		{
 			var optExpr = OptimizeExpr(expr);
-			if (expr == optExpr)
-				return optExpr;
-			else return MultiOptimizer(optExpr);
+			return expr == optExpr 
+				? optExpr 
+				: MultiOptimizer(optExpr);
 		}
 
 		private static string EmitExpr(SqlExpr expr) =>
@@ -35,7 +35,7 @@ namespace SqlDsl.Core
 				SqlBoolAnd(var left, var right) => $"({EmitExpr(left)} AND {EmitExpr(right)})",
 				SqlBoolOr(var left, var right) => $"({EmitExpr(left)} OR {EmitExpr(right)})",
 
-				SqlStringValue(var value) => $"'{value}'",
+        SqlStringValue(var value) => $"'{value}'",
 				SqlStringToUpper(var value) => $"{EmitExpr(value).ToUpper()}",
 				SqlStringToLower(var value) => $"{EmitExpr(value).ToLower()}" ,
           

--- a/src/SqlDsl.Core/SqlIntExpr.cs
+++ b/src/SqlDsl.Core/SqlIntExpr.cs
@@ -6,5 +6,5 @@ namespace SqlDsl.Core
     public record SqlIntPlus(SqlExpr<SqlInt> Value) : SqlExprInt,SqlUnaryExpr<SqlInt>;
     public record SqlIntMinus(SqlExpr<SqlInt> Value) : SqlExprInt,SqlUnaryExpr<SqlInt>;
     public record SqlIntValue(int Value) : SqlExprInt;
-    public record SqlIntAbs(SqlExpr<SqlInt> Value);
+    public record SqlIntAbs(SqlExpr<SqlInt> Value) : SqlExprInt, SqlUnaryExpr<SqlInt>;
 }

--- a/tests/SqlDsl.Core.Tests/SqlBoolTests.cs
+++ b/tests/SqlDsl.Core.Tests/SqlBoolTests.cs
@@ -10,7 +10,7 @@ namespace SqlDsl.Core.Tests
 		[Fact]
 		public void SqlBoolValue()
 		{
-			var sql = SqlTrue.CompileExpr();
+			var sql = SqlCompiler.EmitExpr(SqlTrue);
 			Assert.Equal("TRUE", sql);
 
 			sql = SqlFalse.CompileExpr();
@@ -21,7 +21,7 @@ namespace SqlDsl.Core.Tests
 		public void SqlBoolAnd()
 		{
 			var and = new SqlBoolAnd(SqlTrue, SqlFalse);
-			var sql = and.CompileExpr();
+			var sql = SqlCompiler.EmitExpr(and);
 
 			Assert.Equal("(TRUE AND FALSE)", sql);
 		}
@@ -29,8 +29,8 @@ namespace SqlDsl.Core.Tests
 		[Fact]
 		public void SqlBoolOr()
 		{
-			var and = new SqlBoolOr(SqlTrue, SqlFalse);
-			var sql = and.CompileExpr();
+			var or = new SqlBoolOr(SqlTrue, SqlFalse);
+			var sql = SqlCompiler.EmitExpr(or);
 
 			Assert.Equal("(TRUE OR FALSE)", sql);
 		}
@@ -39,7 +39,7 @@ namespace SqlDsl.Core.Tests
 		public void SqlNotTest()
 		{
 			var notSql = new SqlBoolNot(SqlFalse);
-			var sql = notSql.CompileExpr();
+			var sql = SqlCompiler.EmitExpr(notSql);
 
 			Assert.Equal("NOT (FALSE)", sql);
 		}

--- a/tests/SqlDsl.Core.Tests/SqlIntTests.cs
+++ b/tests/SqlDsl.Core.Tests/SqlIntTests.cs
@@ -7,16 +7,16 @@ namespace SqlDsl.Core.Tests
 	{
 		[Theory]
 		[InlineData(-32, "-32")]
-		[InlineData(32,"32")]
+		[InlineData(32, "32")]
 		[InlineData(0, "0")]
-		public void SqlIntValueTest(int input,string expected)
-        {
+		public void SqlIntValueTest(int input, string expected)
+		{
 			var value = new SqlIntValue(input);
 
-			var sql = value.CompileExpr();
+			var sql = SqlCompiler.EmitExpr(value);
 
-			Assert.Equal(expected,sql);
-        }
+			Assert.Equal(expected, sql);
+		}
 
 		[Fact]
 		public void SqlIntAddTest()
@@ -28,23 +28,23 @@ namespace SqlDsl.Core.Tests
 			var rightSql = new SqlIntValue(right);
 			var sqlAdd = new SqlIntAdd(leftSql, rightSql);
 
-			var sql = sqlAdd.CompileExpr();
+			var sql = SqlCompiler.EmitExpr(sqlAdd);
 
 			Assert.Equal($"({left} + {right})", sql);
 		}
 
 		[Theory]
-		[InlineData(1,2,"(1 - 2)")]
+		[InlineData(1, 2, "(1 - 2)")]
 		[InlineData(1, -2, "(1 - -2)")]
 		[InlineData(-1, 2, "(-1 - 2)")]
 		[InlineData(-1, -2, "(-1 - -2)")]
-		public void SqlIntSubTest(int left,int right,string expected)
-        {
+		public void SqlIntSubTest(int left, int right, string expected)
+		{
 			var leftSql = new SqlIntValue(left);
 			var rightSql = new SqlIntValue(right);
 			var sqlSub = new SqlIntSub(leftSql, rightSql);
 
-			var sql = sqlSub.CompileExpr();
+			var sql = SqlCompiler.EmitExpr(sqlSub);
 
 			Assert.Equal(expected, sql);
 		}
@@ -59,7 +59,7 @@ namespace SqlDsl.Core.Tests
 			var rightSql = new SqlIntValue(right);
 			var sqlMult = new SqlIntMult(leftSql, rightSql);
 
-			var sql = sqlMult.CompileExpr();
+			var sql = SqlCompiler.EmitExpr(sqlMult);
 
 			Assert.Equal($"({left} * {right})", sql);
 		}
@@ -74,34 +74,35 @@ namespace SqlDsl.Core.Tests
 			var sqlPlus = new SqlIntPlus(valueSql);
 
 			// Act
-			var sql = sqlPlus.CompileExpr();
+			var sql = SqlCompiler.EmitExpr(sqlPlus);
 
 			// Assert
 			Assert.Equal($"({value})", sql);
 		}
+
 		[Fact]
 		public void SqlIntMinusTest()
-    {
+		{
 			var value = -32;
 			var valueSql = new SqlIntValue(value);
 
 			var sqlMinus = new SqlIntMinus(valueSql);
 
-			var sql = sqlMinus.CompileExpr();
+			var sql = SqlCompiler.EmitExpr(sqlMinus);
 
 			Assert.Equal($"(-({value}))", sql);
-    }
-    
+		}
+
 		[Theory]
-		[InlineData(32,"(ABS(32))")]
+		[InlineData(32, "(ABS(32))")]
 		[InlineData(-32, "(ABS(-32))")]
 		[InlineData(0, "(ABS(0))")]
-		public void SqlIntAbsTest(int testValue,string expected)
+		public void SqlIntAbsTest(int testValue, string expected)
 		{
 			var valueSql = new SqlIntValue(testValue);
 			var sqlAbs = new SqlIntAbs(valueSql);
 
-			var sql = sqlAbs.CompileExpr();
+			var sql = SqlCompiler.EmitExpr(sqlAbs);
 
 			Assert.Equal(expected, sql);
 		}

--- a/tests/SqlDsl.Core.Tests/SqlStringTests.cs
+++ b/tests/SqlDsl.Core.Tests/SqlStringTests.cs
@@ -15,7 +15,7 @@ namespace SqlDsl.Core.Tests
 
 			var sqlStr = new SqlStringValue(str);
 			var sqlToLower = new SqlStringToLower(sqlStr);
-			var sql = sqlToLower.CompileExpr();
+			var sql = SqlCompiler.EmitExpr(sqlToLower);
 
 			Assert.Equal($"'{"testAbCd".ToLower()}'", sql);
 		}
@@ -25,7 +25,7 @@ namespace SqlDsl.Core.Tests
 		{
 			var sqlStr = new SqlStringValue("testAbCd");
 			var sqlToUpper = new SqlStringToUpper(sqlStr);
-			var sql = sqlToUpper.CompileExpr();
+			var sql = SqlCompiler.EmitExpr(sqlToUpper);
 
 			Assert.Equal($"'{"testAbCd".ToUpper()}'", sql);
 		}


### PR DESCRIPTION
- Fixes tests that were designed with EmitExpr in mind instead of optimized expressions with constant folding.
- Sanitizes SqlIntAbs that was not inheriting SqlIntExpr